### PR TITLE
README - fixes dead get-pip.py link

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Set of simple programs written during learning **basics of Python** language bas
 Pip is a Python Package Manager.
 
 #### Installing Pip on Windows
-1. Download: https://raw.github.com/pypa/pip/master/contrib/get-pip.py script
+1. Download: https://bootstrap.pypa.io/get-pip.py script
 2. Execute: `python get-pip.py`
 3. *pip.exe* and *easy_install.exe* files now should be located at: */PythonXX/Scripts* (e.g. *C:/Python27/Scripts*)
 4. Add */PythonXX/Scripts* (e.g. *C:/Python27/Scripts*) directory into *Path* environmental variable.


### PR DESCRIPTION
My colleague Raven Cooke tried to follow these pip on windows instructions, but the link seems dead (`404: Not Found`) . This replacement link seems to work.